### PR TITLE
add cleanup to autoreport.py entrypoint

### DIFF
--- a/matlabreport/scripts/autoreport.py
+++ b/matlabreport/scripts/autoreport.py
@@ -9,17 +9,18 @@ from matlabreport.openreport import openReport
 
 @click.command()
 @click.option("--pubformat", default="html")
+@click.option("--cleanup", default=True)
 @click.option("--funcs", is_flag=True, help="Append user functions.")
 @click.option("-p", is_flag=True, help="Publish report after building.")
 @click.option("-t", is_flag=True, help="Use pdflatex to typeset report.")
 @click.option("-v", is_flag=True, help="Verbose pdflatex console output.")
 @click.option("-s", is_flag=True, help="Show published report.")
-def autoreport(pubformat, funcs, p, t, v, s):
+def autoreport(pubformat, funcs, cleanup, p, t, v, s):
     """
     Make a MATLAB report m-file, and optionally publish it.
     """
-    outline = os.path.join(".", "outline.yml")
-    report_m = os.path.join(".", "report.m")
+    outline = os.path.abspath(os.path.join(".", "auto_outline.yml"))
+    report_m = os.path.abspath(os.path.join(".", "report.m"))
     makeReport(outline, report_m, funcs, auto=True)
 
     if p is True:
@@ -27,3 +28,14 @@ def autoreport(pubformat, funcs, p, t, v, s):
 
         if s is True:
             openReport(published_report)
+
+    if cleanup is True:
+        htmldir = os.path.join(os.path.split(outline)[0], "html")
+        os.remove(outline)
+        os.remove(report_m)
+
+        if pubformat == "latex" and t is True:
+            extensions = [".log", ".tex", ".aux"]
+            for file in os.listdir(htmldir):
+                if os.path.splitext(file)[1] in extensions:
+                    os.remove(file)


### PR DESCRIPTION
This update adds a cleanup functionality to `autoreport.py` which is on by default. This just means that the autogenerated YAML outline and combined mfile will be deleted after publishing. Additionally, autoreport is run with the options `-p -t --pubformat=latex --cleanup=True`, the `.log`, `.aux`, and `.tex` files will be removed after PDF generation.